### PR TITLE
review: Multi Cluster support

### DIFF
--- a/internal/test/kubernetes.go
+++ b/internal/test/kubernetes.go
@@ -8,15 +8,10 @@ func KubeConfigFake() *clientcmdapi.Config {
 	fakeConfig := clientcmdapi.NewConfig()
 	fakeConfig.Clusters["fake"] = clientcmdapi.NewCluster()
 	fakeConfig.Clusters["fake"].Server = "https://127.0.0.1:6443"
-	fakeConfig.Clusters["additional-cluster"] = clientcmdapi.NewCluster()
 	fakeConfig.AuthInfos["fake"] = clientcmdapi.NewAuthInfo()
-	fakeConfig.AuthInfos["additional-auth"] = clientcmdapi.NewAuthInfo()
 	fakeConfig.Contexts["fake-context"] = clientcmdapi.NewContext()
 	fakeConfig.Contexts["fake-context"].Cluster = "fake"
 	fakeConfig.Contexts["fake-context"].AuthInfo = "fake"
-	fakeConfig.Contexts["additional-context"] = clientcmdapi.NewContext()
-	fakeConfig.Contexts["additional-context"].Cluster = "additional-cluster"
-	fakeConfig.Contexts["additional-context"].AuthInfo = "additional-auth"
 	fakeConfig.CurrentContext = "fake-context"
 	return fakeConfig
 }

--- a/internal/test/mock_server.go
+++ b/internal/test/mock_server.go
@@ -73,10 +73,14 @@ func (m *MockServer) Kubeconfig() *api.Config {
 }
 
 func (m *MockServer) KubeconfigFile(t *testing.T) string {
-	kubeconfig := filepath.Join(t.TempDir(), "config")
-	err := clientcmd.WriteToFile(*m.Kubeconfig(), kubeconfig)
+	return KubeconfigFile(t, m.Kubeconfig())
+}
+
+func KubeconfigFile(t *testing.T, kubeconfig *api.Config) string {
+	kubeconfigFile := filepath.Join(t.TempDir(), "config")
+	err := clientcmd.WriteToFile(*kubeconfig, kubeconfigFile)
 	require.NoError(t, err, "Expected no error writing kubeconfig file")
-	return kubeconfig
+	return kubeconfigFile
 }
 
 func WriteObject(w http.ResponseWriter, obj runtime.Object) {

--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -10,8 +10,19 @@ import (
 )
 
 type ServerTool struct {
-	Tool    Tool
-	Handler ToolHandlerFunc
+	Tool         Tool
+	Handler      ToolHandlerFunc
+	ClusterAware *bool `json:"-"`
+}
+
+// IsClusterAware indicates whether the tool can accept a "cluster" or "context" parameter
+// to operate on a specific Kubernetes cluster context.
+func (s *ServerTool) IsClusterAware() bool {
+	if s.ClusterAware != nil {
+		return *s.ClusterAware
+	}
+	// Default to true if not explicitly set
+	return true
 }
 
 type Toolset interface {

--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -10,19 +10,29 @@ import (
 )
 
 type ServerTool struct {
-	Tool         Tool
-	Handler      ToolHandlerFunc
-	ClusterAware *bool `json:"-"`
+	Tool               Tool
+	Handler            ToolHandlerFunc
+	ClusterAware       *bool
+	TargetListProvider *bool
 }
 
 // IsClusterAware indicates whether the tool can accept a "cluster" or "context" parameter
 // to operate on a specific Kubernetes cluster context.
+// Defaults to true if not explicitly set
 func (s *ServerTool) IsClusterAware() bool {
 	if s.ClusterAware != nil {
 		return *s.ClusterAware
 	}
-	// Default to true if not explicitly set
 	return true
+}
+
+// IsTargetListProvider indicates whether the tool is used to provide a list of targets (clusters/contexts)
+// Defaults to false if not explicitly set
+func (s *ServerTool) IsTargetListProvider() bool {
+	if s.TargetListProvider != nil {
+		return *s.TargetListProvider
+	}
+	return false
 }
 
 type Toolset interface {

--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -55,7 +55,6 @@ func NewToolCallResult(content string, err error) *ToolCallResult {
 type ToolHandlerParams struct {
 	context.Context
 	*internalk8s.Kubernetes
-	internalk8s.ManagerProvider
 	ToolCallRequest
 	ListOutput output.Output
 }

--- a/pkg/api/toolsets_test.go
+++ b/pkg/api/toolsets_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"k8s.io/utils/ptr"
+)
+
+type ToolsetsSuite struct {
+	suite.Suite
+}
+
+func (s *ToolsetsSuite) TestServerTool() {
+	s.Run("IsClusterAware", func() {
+		s.Run("defaults to true", func() {
+			tool := &ServerTool{}
+			s.True(tool.IsClusterAware(), "Expected IsClusterAware to be true by default")
+		})
+		s.Run("can be set to false", func() {
+			tool := &ServerTool{ClusterAware: ptr.To(false)}
+			s.False(tool.IsClusterAware(), "Expected IsClusterAware to be false when set to false")
+		})
+		s.Run("can be set to true", func() {
+			tool := &ServerTool{ClusterAware: ptr.To(true)}
+			s.True(tool.IsClusterAware(), "Expected IsClusterAware to be true when set to true")
+		})
+	})
+	s.Run("IsTargetListProvider", func() {
+		s.Run("defaults to false", func() {
+			tool := &ServerTool{}
+			s.False(tool.IsTargetListProvider(), "Expected IsTargetListProvider to be false by default")
+		})
+		s.Run("can be set to false", func() {
+			tool := &ServerTool{TargetListProvider: ptr.To(false)}
+			s.False(tool.IsTargetListProvider(), "Expected IsTargetListProvider to be false when set to false")
+		})
+		s.Run("can be set to true", func() {
+			tool := &ServerTool{TargetListProvider: ptr.To(true)}
+			s.True(tool.IsTargetListProvider(), "Expected IsTargetListProvider to be true when set to true")
+		})
+	})
+}
+
+func TestToolsets(t *testing.T) {
+	suite.Run(t, new(ToolsetsSuite))
+}

--- a/pkg/mcp/configuration_test.go
+++ b/pkg/mcp/configuration_test.go
@@ -1,7 +1,7 @@
 package mcp
 
 import (
-	"strconv"
+	"fmt"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -27,7 +27,13 @@ func (s *ConfigurationSuite) SetupTest() {
 	kubeconfig := mockServer.Kubeconfig()
 	for i := 0; i < 10; i++ {
 		// Add multiple fake contexts to force configuration_contexts_list tool to appear
-		kubeconfig.Contexts[strconv.Itoa(i)] = clientcmdapi.NewContext()
+		// and test minification in configuration_view tool
+		name := fmt.Sprintf("cluster-%d", i)
+		kubeconfig.Contexts[name] = clientcmdapi.NewContext()
+		kubeconfig.Clusters[name+"-cluster"] = clientcmdapi.NewCluster()
+		kubeconfig.AuthInfos[name+"-auth"] = clientcmdapi.NewAuthInfo()
+		kubeconfig.Contexts[name].Cluster = name + "-cluster"
+		kubeconfig.Contexts[name].AuthInfo = name + "-auth"
 	}
 	s.Cfg.KubeConfig = test.KubeconfigFile(s.T(), kubeconfig)
 }
@@ -42,7 +48,7 @@ func (s *ConfigurationSuite) TestContextsList() {
 		s.Require().NotNil(toolResult, "Expected tool result from call")
 		s.Lenf(toolResult.Content, 1, "invalid tool result content length %v", len(toolResult.Content))
 		s.Run("contains context count", func() {
-			s.Regexpf(`^Available Kubernetes contexts \(12 total`, toolResult.Content[0].(mcp.TextContent).Text, "invalid tool count result content %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Regexpf(`^Available Kubernetes contexts \(11 total`, toolResult.Content[0].(mcp.TextContent).Text, "invalid tool count result content %v", toolResult.Content[0].(mcp.TextContent).Text)
 		})
 		s.Run("contains default context name", func() {
 			s.Regexpf(`^Available Kubernetes contexts \(\d+ total, default: fake-context\)`, toolResult.Content[0].(mcp.TextContent).Text, "invalid tool context default result content %v", toolResult.Content[0].(mcp.TextContent).Text)
@@ -96,19 +102,23 @@ func (s *ConfigurationSuite) TestConfigurationView() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
 		s.Run("returns additional context info", func() {
-			s.Lenf(decoded.Contexts, 12, "invalid context count, expected 12, got %v", len(decoded.Contexts))
-			s.Equalf("additional-context", decoded.Contexts[10].Name, "additional-context not found: %v", decoded.Contexts)
-			s.Equalf("additional-cluster", decoded.Contexts[10].Context.Cluster, "additional-cluster not found: %v", decoded.Contexts)
-			s.Equalf("additional-auth", decoded.Contexts[10].Context.AuthInfo, "additional-auth not found: %v", decoded.Contexts)
-			s.Equalf("fake-context", decoded.Contexts[11].Name, "fake-context not found: %v", decoded.Contexts)
+			s.Lenf(decoded.Contexts, 11, "invalid context count, expected 12, got %v", len(decoded.Contexts))
+			s.Equalf("cluster-0", decoded.Contexts[0].Name, "cluster-0 not found: %v", decoded.Contexts)
+			s.Equalf("cluster-0-cluster", decoded.Contexts[0].Context.Cluster, "cluster-0-cluster not found: %v", decoded.Contexts)
+			s.Equalf("cluster-0-auth", decoded.Contexts[0].Context.AuthInfo, "cluster-0-auth not found: %v", decoded.Contexts)
+			s.Equalf("fake", decoded.Contexts[10].Context.Cluster, "fake not found: %v", decoded.Contexts)
+			s.Equalf("fake", decoded.Contexts[10].Context.AuthInfo, "fake not found: %v", decoded.Contexts)
+			s.Equalf("fake-context", decoded.Contexts[10].Name, "fake-context not found: %v", decoded.Contexts)
 		})
 		s.Run("returns cluster info", func() {
-			s.Lenf(decoded.Clusters, 2, "invalid cluster count, expected 2, got %v", len(decoded.Clusters))
-			s.Equalf("additional-cluster", decoded.Clusters[0].Name, "additional-cluster not found: %v", decoded.Clusters)
+			s.Lenf(decoded.Clusters, 11, "invalid cluster count, expected 2, got %v", len(decoded.Clusters))
+			s.Equalf("cluster-0-cluster", decoded.Clusters[0].Name, "cluster-0-cluster not found: %v", decoded.Clusters)
+			s.Equalf("fake", decoded.Clusters[10].Name, "fake not found: %v", decoded.Clusters)
 		})
 		s.Run("configuration_view with minified=false returns auth info", func() {
-			s.Lenf(decoded.AuthInfos, 2, "invalid auth info count, expected 2, got %v", len(decoded.AuthInfos))
-			s.Equalf("additional-auth", decoded.AuthInfos[0].Name, "additional-auth not found: %v", decoded.AuthInfos)
+			s.Lenf(decoded.AuthInfos, 11, "invalid auth info count, expected 2, got %v", len(decoded.AuthInfos))
+			s.Equalf("cluster-0-auth", decoded.AuthInfos[0].Name, "cluster-0-auth not found: %v", decoded.AuthInfos)
+			s.Equalf("fake", decoded.AuthInfos[10].Name, "fake not found: %v", decoded.AuthInfos)
 		})
 	})
 }

--- a/pkg/mcp/m3labs.go
+++ b/pkg/mcp/m3labs.go
@@ -55,7 +55,6 @@ func ServerToolToM3LabsServerTool(s *Server, tools []api.ServerTool) ([]server.S
 			result, err := tool.Handler(api.ToolHandlerParams{
 				Context:         ctx,
 				Kubernetes:      k,
-				ManagerProvider: s.p,
 				ToolCallRequest: request,
 				ListOutput:      s.configuration.ListOutput(),
 			})

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -132,7 +132,7 @@ func (s *Server) reloadKubernetesClusterProvider() error {
 		p.GetDefaultTarget(),
 		p.GetTargetParameterName(),
 		targets,
-		[]string{"configuration_view", "contexts_list"}, // TODO: see which tools (if any) do not need the cluster parameter
+		[]string{"configuration_view", "configuration_contexts_list"}, // TODO: see which tools (if any) do not need the cluster parameter
 	)
 
 	applicableTools := make([]api.ServerTool, 0)

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -132,7 +132,6 @@ func (s *Server) reloadKubernetesClusterProvider() error {
 		p.GetDefaultTarget(),
 		p.GetTargetParameterName(),
 		targets,
-		[]string{"configuration_view", "configuration_contexts_list"}, // TODO: see which tools (if any) do not need the cluster parameter
 	)
 
 	applicableTools := make([]api.ServerTool, 0)

--- a/pkg/mcp/mcp_tools_test.go
+++ b/pkg/mcp/mcp_tools_test.go
@@ -34,12 +34,7 @@ func TestUnrestricted(t *testing.T) {
 }
 
 func TestReadOnly(t *testing.T) {
-	readOnlyServer := func(c *mcpContext) {
-		c.staticConfig = &config.StaticConfig{
-			ReadOnly:                true,
-			ClusterProviderStrategy: config.ClusterProviderKubeConfig,
-		}
-	}
+	readOnlyServer := func(c *mcpContext) { c.staticConfig = &config.StaticConfig{ReadOnly: true} }
 	testCaseWithContext(t, &mcpContext{before: readOnlyServer}, func(c *mcpContext) {
 		tools, err := c.mcpClient.ListTools(c.ctx, mcp.ListToolsRequest{})
 		t.Run("ListTools returns tools", func(t *testing.T) {
@@ -61,12 +56,7 @@ func TestReadOnly(t *testing.T) {
 }
 
 func TestDisableDestructive(t *testing.T) {
-	disableDestructiveServer := func(c *mcpContext) {
-		c.staticConfig = &config.StaticConfig{
-			DisableDestructive:      true,
-			ClusterProviderStrategy: config.ClusterProviderKubeConfig,
-		}
-	}
+	disableDestructiveServer := func(c *mcpContext) { c.staticConfig = &config.StaticConfig{DisableDestructive: true} }
 	testCaseWithContext(t, &mcpContext{before: disableDestructiveServer}, func(c *mcpContext) {
 		tools, err := c.mcpClient.ListTools(c.ctx, mcp.ListToolsRequest{})
 		t.Run("ListTools returns tools", func(t *testing.T) {
@@ -111,8 +101,7 @@ func TestEnabledTools(t *testing.T) {
 func TestDisabledTools(t *testing.T) {
 	testCaseWithContext(t, &mcpContext{
 		staticConfig: &config.StaticConfig{
-			DisabledTools:           []string{"namespaces_list", "events_list"},
-			ClusterProviderStrategy: config.ClusterProviderKubeConfig,
+			DisabledTools: []string{"namespaces_list", "events_list"},
 		},
 	}, func(c *mcpContext) {
 		tools, err := c.mcpClient.ListTools(c.ctx, mcp.ListToolsRequest{})

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster-enum.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster-enum.json
@@ -1,6 +1,26 @@
 [
   {
     "annotations": {
+      "title": "Configuration: View",
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": true
+    },
+    "description": "Get the current Kubernetes configuration content as a kubeconfig YAML",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "minified": {
+          "description": "Return a minified version of the configuration. If set to true, keeps only the current-context and the relevant pieces of the configuration for that context. If set to false, all contexts, clusters, auth-infos, and users are returned in the configuration. (Optional, default true)",
+          "type": "boolean"
+        }
+      }
+    },
+    "name": "configuration_view"
+  },
+  {
+    "annotations": {
       "title": "Events: List",
       "readOnlyHint": true,
       "destructiveHint": false,
@@ -11,6 +31,14 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
+          "type": "string"
+        },
         "namespace": {
           "description": "Optional Namespace to retrieve the events from. If not provided, will list events from all namespaces",
           "type": "string"
@@ -18,6 +46,116 @@
       }
     },
     "name": "events_list"
+  },
+  {
+    "annotations": {
+      "title": "Helm: Install",
+      "readOnlyHint": false,
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": true
+    },
+    "description": "Install a Helm chart in the current or provided namespace",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "chart": {
+          "description": "Chart reference to install (for example: stable/grafana, oci://ghcr.io/nginxinc/charts/nginx-ingress)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Helm release (Optional, random name if not provided)",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to install the Helm chart in (Optional, current namespace if not provided)",
+          "type": "string"
+        },
+        "values": {
+          "description": "Values to pass to the Helm chart (Optional)",
+          "type": "object"
+        }
+      },
+      "required": [
+        "chart"
+      ]
+    },
+    "name": "helm_install"
+  },
+  {
+    "annotations": {
+      "title": "Helm: List",
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": true
+    },
+    "description": "List all the Helm releases in the current or provided namespace (or in all namespaces if specified)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "all_namespaces": {
+          "description": "If true, lists all Helm releases in all namespaces ignoring the namespace argument (Optional)",
+          "type": "boolean"
+        },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to list Helm releases from (Optional, all namespaces if not provided)",
+          "type": "string"
+        }
+      }
+    },
+    "name": "helm_list"
+  },
+  {
+    "annotations": {
+      "title": "Helm: Uninstall",
+      "readOnlyHint": false,
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true
+    },
+    "description": "Uninstall a Helm release in the current or provided namespace",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Helm release to uninstall",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to uninstall the Helm release from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "name": "helm_uninstall"
   },
   {
     "annotations": {
@@ -29,7 +167,17 @@
     },
     "description": "List all the Kubernetes namespaces in the current cluster",
     "inputSchema": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
+          "type": "string"
+        }
+      }
     },
     "name": "namespaces_list"
   },
@@ -45,6 +193,14 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
+          "type": "string"
+        },
         "name": {
           "description": "Name of the Pod to delete",
           "type": "string"
@@ -83,6 +239,14 @@
           "description": "Name of the Pod container where the command will be executed (Optional)",
           "type": "string"
         },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
+          "type": "string"
+        },
         "name": {
           "description": "Name of the Pod where the command will be executed",
           "type": "string"
@@ -111,6 +275,14 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
+          "type": "string"
+        },
         "name": {
           "description": "Name of the Pod",
           "type": "string"
@@ -138,6 +310,14 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
+          "type": "string"
+        },
         "labelSelector": {
           "description": "Optional Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]",
@@ -159,6 +339,14 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
+          "type": "string"
+        },
         "labelSelector": {
           "description": "Optional Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]",
@@ -189,6 +377,14 @@
       "properties": {
         "container": {
           "description": "Name of the Pod container to get the logs from (Optional)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
           "type": "string"
         },
         "name": {
@@ -228,6 +424,14 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
+          "type": "string"
+        },
         "image": {
           "description": "Container Image to run in the Pod",
           "type": "string"
@@ -268,6 +472,14 @@
           "description": "If true, list the resource consumption for all Pods in all namespaces. If false, list the resource consumption for Pods in the provided namespace or the current namespace",
           "type": "boolean"
         },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
+          "type": "string"
+        },
         "label_selector": {
           "description": "Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label (Optional, only applicable when name is not provided)",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]",
@@ -297,6 +509,14 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
+          "type": "string"
+        },
         "resource": {
           "description": "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec",
           "type": "string"
@@ -322,6 +542,14 @@
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
           "type": "string"
         },
         "kind": {
@@ -361,6 +589,14 @@
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
         },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
+          "type": "string"
+        },
         "kind": {
           "description": "kind of the resource (examples of valid kind are: Pod, Service, Deployment, Ingress)",
           "type": "string"
@@ -396,6 +632,14 @@
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "enum": [
+            "extra-cluster",
+            "fake-context"
+          ],
           "type": "string"
         },
         "kind": {

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
@@ -1,6 +1,40 @@
 [
   {
     "annotations": {
+      "title": "Configuration: Contexts List",
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false
+    },
+    "description": "List all available context names from the kubeconfig file",
+    "inputSchema": {
+      "type": "object"
+    },
+    "name": "configuration_contexts_list"
+  },
+  {
+    "annotations": {
+      "title": "Configuration: View",
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": true
+    },
+    "description": "Get the current Kubernetes configuration content as a kubeconfig YAML",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "minified": {
+          "description": "Return a minified version of the configuration. If set to true, keeps only the current-context and the relevant pieces of the configuration for that context. If set to false, all contexts, clusters, auth-infos, and users are returned in the configuration. (Optional, default true)",
+          "type": "boolean"
+        }
+      }
+    },
+    "name": "configuration_view"
+  },
+  {
+    "annotations": {
       "title": "Events: List",
       "readOnlyHint": true,
       "destructiveHint": false,
@@ -11,6 +45,10 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
         "namespace": {
           "description": "Optional Namespace to retrieve the events from. If not provided, will list events from all namespaces",
           "type": "string"
@@ -18,6 +56,104 @@
       }
     },
     "name": "events_list"
+  },
+  {
+    "annotations": {
+      "title": "Helm: Install",
+      "readOnlyHint": false,
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": true
+    },
+    "description": "Install a Helm chart in the current or provided namespace",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "chart": {
+          "description": "Chart reference to install (for example: stable/grafana, oci://ghcr.io/nginxinc/charts/nginx-ingress)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Helm release (Optional, random name if not provided)",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to install the Helm chart in (Optional, current namespace if not provided)",
+          "type": "string"
+        },
+        "values": {
+          "description": "Values to pass to the Helm chart (Optional)",
+          "type": "object"
+        }
+      },
+      "required": [
+        "chart"
+      ]
+    },
+    "name": "helm_install"
+  },
+  {
+    "annotations": {
+      "title": "Helm: List",
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": true
+    },
+    "description": "List all the Helm releases in the current or provided namespace (or in all namespaces if specified)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "all_namespaces": {
+          "description": "If true, lists all Helm releases in all namespaces ignoring the namespace argument (Optional)",
+          "type": "boolean"
+        },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to list Helm releases from (Optional, all namespaces if not provided)",
+          "type": "string"
+        }
+      }
+    },
+    "name": "helm_list"
+  },
+  {
+    "annotations": {
+      "title": "Helm: Uninstall",
+      "readOnlyHint": false,
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true
+    },
+    "description": "Uninstall a Helm release in the current or provided namespace",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Helm release to uninstall",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to uninstall the Helm release from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "name": "helm_uninstall"
   },
   {
     "annotations": {
@@ -29,7 +165,13 @@
     },
     "description": "List all the Kubernetes namespaces in the current cluster",
     "inputSchema": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        }
+      }
     },
     "name": "namespaces_list"
   },
@@ -45,6 +187,10 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
         "name": {
           "description": "Name of the Pod to delete",
           "type": "string"
@@ -83,6 +229,10 @@
           "description": "Name of the Pod container where the command will be executed (Optional)",
           "type": "string"
         },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
         "name": {
           "description": "Name of the Pod where the command will be executed",
           "type": "string"
@@ -111,6 +261,10 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
         "name": {
           "description": "Name of the Pod",
           "type": "string"
@@ -138,6 +292,10 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
         "labelSelector": {
           "description": "Optional Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]",
@@ -159,6 +317,10 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
         "labelSelector": {
           "description": "Optional Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]",
@@ -189,6 +351,10 @@
       "properties": {
         "container": {
           "description": "Name of the Pod container to get the logs from (Optional)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
           "type": "string"
         },
         "name": {
@@ -228,6 +394,10 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
         "image": {
           "description": "Container Image to run in the Pod",
           "type": "string"
@@ -268,6 +438,10 @@
           "description": "If true, list the resource consumption for all Pods in all namespaces. If false, list the resource consumption for Pods in the provided namespace or the current namespace",
           "type": "boolean"
         },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
         "label_selector": {
           "description": "Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label (Optional, only applicable when name is not provided)",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]",
@@ -297,6 +471,10 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
         "resource": {
           "description": "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec",
           "type": "string"
@@ -322,6 +500,10 @@
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
           "type": "string"
         },
         "kind": {
@@ -361,6 +543,10 @@
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
         },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
         "kind": {
           "description": "kind of the resource (examples of valid kind are: Pod, Service, Deployment, Ingress)",
           "type": "string"
@@ -396,6 +582,10 @@
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
           "type": "string"
         },
         "kind": {

--- a/pkg/mcp/testdata/toolsets-full-tools-openshift.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-openshift.json
@@ -31,14 +31,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "namespace": {
           "description": "Optional Namespace to retrieve the events from. If not provided, will list events from all namespaces",
           "type": "string"
@@ -59,14 +51,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "chart": {
           "description": "Chart reference to install (for example: stable/grafana, oci://ghcr.io/nginxinc/charts/nginx-ingress)",
           "type": "string"
@@ -102,14 +86,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "all_namespaces": {
           "description": "If true, lists all Helm releases in all namespaces ignoring the namespace argument (Optional)",
           "type": "boolean"
@@ -134,14 +110,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "name": {
           "description": "Name of the Helm release to uninstall",
           "type": "string"
@@ -167,17 +135,7 @@
     },
     "description": "List all the Kubernetes namespaces in the current cluster",
     "inputSchema": {
-      "type": "object",
-      "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        }
-      }
+      "type": "object"
     },
     "name": "namespaces_list"
   },
@@ -193,14 +151,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "name": {
           "description": "Name of the Pod to delete",
           "type": "string"
@@ -228,14 +178,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "command": {
           "description": "Command to execute in the Pod container. The first item is the command to be run, and the rest are the arguments to that command. Example: [\"ls\", \"-l\", \"/tmp\"]",
           "items": {
@@ -275,14 +217,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "name": {
           "description": "Name of the Pod",
           "type": "string"
@@ -310,14 +244,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "labelSelector": {
           "description": "Optional Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]",
@@ -339,14 +265,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "labelSelector": {
           "description": "Optional Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]",
@@ -375,14 +293,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "container": {
           "description": "Name of the Pod container to get the logs from (Optional)",
           "type": "string"
@@ -424,14 +334,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "image": {
           "description": "Container Image to run in the Pod",
           "type": "string"
@@ -467,14 +369,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "all_namespaces": {
           "default": true,
           "description": "If true, list the resource consumption for all Pods in all namespaces. If false, list the resource consumption for Pods in the provided namespace or the current namespace",
@@ -507,17 +401,7 @@
     },
     "description": "List all the OpenShift projects in the current cluster",
     "inputSchema": {
-      "type": "object",
-      "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        }
-      }
+      "type": "object"
     },
     "name": "projects_list"
   },
@@ -533,14 +417,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "resource": {
           "description": "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec",
           "type": "string"
@@ -564,14 +440,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
@@ -609,14 +477,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
@@ -654,14 +514,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "apiVersion": {
           "description": "apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"

--- a/pkg/mcp/testdata/toolsets-full-tools.json
+++ b/pkg/mcp/testdata/toolsets-full-tools.json
@@ -31,14 +31,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "namespace": {
           "description": "Optional Namespace to retrieve the events from. If not provided, will list events from all namespaces",
           "type": "string"
@@ -59,14 +51,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "chart": {
           "description": "Chart reference to install (for example: stable/grafana, oci://ghcr.io/nginxinc/charts/nginx-ingress)",
           "type": "string"
@@ -102,14 +86,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "all_namespaces": {
           "description": "If true, lists all Helm releases in all namespaces ignoring the namespace argument (Optional)",
           "type": "boolean"
@@ -134,14 +110,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "name": {
           "description": "Name of the Helm release to uninstall",
           "type": "string"
@@ -167,17 +135,7 @@
     },
     "description": "List all the Kubernetes namespaces in the current cluster",
     "inputSchema": {
-      "type": "object",
-      "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        }
-      }
+      "type": "object"
     },
     "name": "namespaces_list"
   },
@@ -193,14 +151,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "name": {
           "description": "Name of the Pod to delete",
           "type": "string"
@@ -228,14 +178,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "command": {
           "description": "Command to execute in the Pod container. The first item is the command to be run, and the rest are the arguments to that command. Example: [\"ls\", \"-l\", \"/tmp\"]",
           "items": {
@@ -275,14 +217,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "name": {
           "description": "Name of the Pod",
           "type": "string"
@@ -310,14 +244,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "labelSelector": {
           "description": "Optional Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]",
@@ -339,14 +265,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "labelSelector": {
           "description": "Optional Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]",
@@ -375,14 +293,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "container": {
           "description": "Name of the Pod container to get the logs from (Optional)",
           "type": "string"
@@ -424,14 +334,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "image": {
           "description": "Container Image to run in the Pod",
           "type": "string"
@@ -467,14 +369,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "all_namespaces": {
           "default": true,
           "description": "If true, list the resource consumption for all Pods in all namespaces. If false, list the resource consumption for Pods in the provided namespace or the current namespace",
@@ -509,14 +403,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "resource": {
           "description": "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec",
           "type": "string"
@@ -540,14 +426,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
@@ -585,14 +463,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
@@ -630,14 +500,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "apiVersion": {
           "description": "apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"

--- a/pkg/mcp/testdata/toolsets-helm-tools.json
+++ b/pkg/mcp/testdata/toolsets-helm-tools.json
@@ -11,14 +11,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "chart": {
           "description": "Chart reference to install (for example: stable/grafana, oci://ghcr.io/nginxinc/charts/nginx-ingress)",
           "type": "string"
@@ -54,14 +46,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "all_namespaces": {
           "description": "If true, lists all Helm releases in all namespaces ignoring the namespace argument (Optional)",
           "type": "boolean"
@@ -86,14 +70,6 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "context": {
-          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
-          "enum": [
-            "additional-context",
-            "fake-context"
-          ],
-          "type": "string"
-        },
         "name": {
           "description": "Name of the Helm release to uninstall",
           "type": "string"

--- a/pkg/mcp/tool_filter.go
+++ b/pkg/mcp/tool_filter.go
@@ -5,6 +5,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 )
 
+// ToolFilter is a function that takes a ServerTool and returns a boolean indicating whether to include the tool
 type ToolFilter func(tool api.ServerTool) bool
 
 func CompositeFilter(filters ...ToolFilter) ToolFilter {
@@ -21,16 +22,18 @@ func CompositeFilter(filters ...ToolFilter) ToolFilter {
 
 func ShouldIncludeTargetListTool(targetName string, targets []string) ToolFilter {
 	return func(tool api.ServerTool) bool {
-		if tool.Tool.Name == "configuration_contexts_list" {
-			if targetName != kubernetes.KubeConfigTargetParameterName {
-				// let's not include configuration_contexts_list if we aren't targeting contexts in our ManagerProvider
-				return false
-			}
+		if !tool.IsTargetListProvider() {
+			return true
+		}
+		if len(targets) <= maxTargetsInEnum {
+			// all targets in enum, no need for target list provider tool
+			return false
+		}
 
-			if len(targets) <= maxTargetsInEnum {
-				// all targets in enum, no need for configuration_contexts_list tool
-				return false
-			}
+		// TODO: this check should be removed or make more generic when we have other
+		if tool.Tool.Name == "configuration_contexts_list" && targetName != kubernetes.KubeConfigTargetParameterName {
+			// let's not include configuration_contexts_list if we aren't targeting contexts in our ManagerProvider
+			return false
 		}
 
 		return true

--- a/pkg/mcp/tool_filter.go
+++ b/pkg/mcp/tool_filter.go
@@ -21,14 +21,14 @@ func CompositeFilter(filters ...ToolFilter) ToolFilter {
 
 func ShouldIncludeTargetListTool(targetName string, targets []string) ToolFilter {
 	return func(tool api.ServerTool) bool {
-		if tool.Tool.Name == "contexts_list" {
+		if tool.Tool.Name == "configuration_contexts_list" {
 			if targetName != kubernetes.KubeConfigTargetParameterName {
-				// let's not include contexts_list if we aren't targetting contexts in our ManagerProvider
+				// let's not include configuration_contexts_list if we aren't targeting contexts in our ManagerProvider
 				return false
 			}
 
 			if len(targets) <= maxTargetsInEnum {
-				// all targets in enum, no need for contexts_list tool
+				// all targets in enum, no need for configuration_contexts_list tool
 				return false
 			}
 		}

--- a/pkg/mcp/tool_filter_test.go
+++ b/pkg/mcp/tool_filter_test.go
@@ -1,0 +1,84 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/utils/ptr"
+)
+
+type ToolFilterSuite struct {
+	suite.Suite
+}
+
+func (s *ToolFilterSuite) TestToolFilterType() {
+	s.Run("ToolFilter type can be used as function", func() {
+		var mutator ToolFilter = func(tool api.ServerTool) bool {
+			return tool.Tool.Name == "included"
+		}
+		s.Run("returns true for included tool", func() {
+			tool := api.ServerTool{Tool: api.Tool{Name: "included"}}
+			s.True(mutator(tool))
+		})
+		s.Run("returns false for excluded tool", func() {
+			tool := api.ServerTool{Tool: api.Tool{Name: "excluded"}}
+			s.False(mutator(tool))
+		})
+	})
+}
+
+func (s *ToolFilterSuite) TestCompositeFilter() {
+	s.Run("returns true if all filters return true", func() {
+		filter := CompositeFilter(
+			func(tool api.ServerTool) bool { return true },
+			func(tool api.ServerTool) bool { return true },
+		)
+		tool := api.ServerTool{Tool: api.Tool{Name: "test"}}
+		s.True(filter(tool))
+	})
+	s.Run("returns false if any filter returns false", func() {
+		filter := CompositeFilter(
+			func(tool api.ServerTool) bool { return true },
+			func(tool api.ServerTool) bool { return false },
+		)
+		tool := api.ServerTool{Tool: api.Tool{Name: "test"}}
+		s.False(filter(tool))
+	})
+}
+
+func (s *ToolFilterSuite) TestShouldIncludeTargetListTool() {
+	s.Run("non-target-list-provider tools: returns true ", func() {
+		filter := ShouldIncludeTargetListTool("any", []string{"a", "b", "c", "d", "e", "f"})
+		tool := api.ServerTool{Tool: api.Tool{Name: "test"}, TargetListProvider: ptr.To(false)}
+		s.True(filter(tool))
+	})
+	s.Run("target-list-provider tools", func() {
+		s.Run("with targets <= 5: returns false", func() {
+			filter := ShouldIncludeTargetListTool("any", []string{"1", "2", "3", "4", "5"})
+			tool := api.ServerTool{Tool: api.Tool{Name: "test"}, TargetListProvider: ptr.To(true)}
+			s.False(filter(tool))
+		})
+		s.Run("with targets <= 5", func() {
+			s.Run("and tool is configuration_contexts_list and targetName is not context: returns false", func() {
+				filter := ShouldIncludeTargetListTool("not_context", []string{"1", "2", "3", "4", "5", "6"})
+				tool := api.ServerTool{Tool: api.Tool{Name: "configuration_contexts_list"}, TargetListProvider: ptr.To(true)}
+				s.False(filter(tool))
+			})
+			s.Run("and tool is configuration_contexts_list and targetName is context: returns true", func() {
+				filter := ShouldIncludeTargetListTool("context", []string{"1", "2", "3", "4", "5", "6"})
+				tool := api.ServerTool{Tool: api.Tool{Name: "configuration_contexts_list"}, TargetListProvider: ptr.To(true)}
+				s.True(filter(tool))
+			})
+			s.Run("and tool is not configuration_contexts_list: returns true", func() {
+				filter := ShouldIncludeTargetListTool("any", []string{"1", "2", "3", "4", "5", "6"})
+				tool := api.ServerTool{Tool: api.Tool{Name: "other_tool"}, TargetListProvider: ptr.To(true)}
+				s.True(filter(tool))
+			})
+		})
+	})
+}
+
+func TestToolFilter(t *testing.T) {
+	suite.Run(t, new(ToolFilterSuite))
+}

--- a/pkg/mcp/tool_mutator.go
+++ b/pkg/mcp/tool_mutator.go
@@ -12,14 +12,10 @@ type ToolMutator func(tool api.ServerTool) api.ServerTool
 
 const maxTargetsInEnum = 5 // TODO: test and validate that this is a reasonable cutoff
 
-func WithTargetParameter(defaultCluster, targetParameterName string, targets, skipToolNames []string) ToolMutator {
-	skipNames := make(map[string]struct{}, len(skipToolNames))
-	for _, n := range skipToolNames {
-		skipNames[n] = struct{}{}
-	}
-
+// WithTargetParameter adds a target selection parameter to the tool's input schema if the tool is cluster-aware
+func WithTargetParameter(defaultCluster, targetParameterName string, targets []string) ToolMutator {
 	return func(tool api.ServerTool) api.ServerTool {
-		if _, ok := skipNames[tool.Tool.Name]; ok {
+		if !tool.IsClusterAware() {
 			return tool
 		}
 

--- a/pkg/mcp/toolsets_test.go
+++ b/pkg/mcp/toolsets_test.go
@@ -2,10 +2,8 @@ package mcp
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
-
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/stretchr/testify/suite"
 
 	"github.com/containers/kubernetes-mcp-server/internal/test"
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
@@ -14,6 +12,9 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/core"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/helm"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/suite"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 type ToolsetsSuite struct {
@@ -91,6 +92,50 @@ func (s *ToolsetsSuite) TestDefaultToolsetsToolsInOpenShift() {
 		})
 		s.Run("ListTools returns correct Tool metadata", func() {
 			expectedMetadata := test.ReadFile("testdata", "toolsets-full-tools-openshift.json")
+			metadata, err := json.MarshalIndent(tools.Tools, "", "  ")
+			s.Require().NoErrorf(err, "failed to marshal tools metadata: %v", err)
+			s.JSONEq(expectedMetadata, string(metadata), "tools metadata does not match expected")
+		})
+	})
+}
+
+func (s *ToolsetsSuite) TestDefaultToolsetsToolsInMultiCluster() {
+	s.Run("Default configuration toolsets in multi-cluster (with 11 clusters)", func() {
+		kubeconfig := s.Kubeconfig()
+		for i := 0; i < 10; i++ {
+			// Add multiple fake contexts to force multi-cluster behavior
+			kubeconfig.Contexts[strconv.Itoa(i)] = clientcmdapi.NewContext()
+		}
+		s.Cfg.KubeConfig = test.KubeconfigFile(s.T(), kubeconfig)
+		s.InitMcpClient()
+		tools, err := s.ListTools(s.T().Context(), mcp.ListToolsRequest{})
+		s.Run("ListTools returns tools", func() {
+			s.NotNil(tools, "Expected tools from ListTools")
+			s.NoError(err, "Expected no error from ListTools")
+		})
+		s.Run("ListTools returns correct Tool metadata", func() {
+			expectedMetadata := test.ReadFile("testdata", "toolsets-full-tools-multicluster.json")
+			metadata, err := json.MarshalIndent(tools.Tools, "", "  ")
+			s.Require().NoErrorf(err, "failed to marshal tools metadata: %v", err)
+			s.JSONEq(expectedMetadata, string(metadata), "tools metadata does not match expected")
+		})
+	})
+}
+
+func (s *ToolsetsSuite) TestDefaultToolsetsToolsInMultiClusterEnum() {
+	s.Run("Default configuration toolsets in multi-cluster (with 2 clusters)", func() {
+		kubeconfig := s.Kubeconfig()
+		// Add additional cluster to force multi-cluster behavior with enum parameter
+		kubeconfig.Contexts["extra-cluster"] = clientcmdapi.NewContext()
+		s.Cfg.KubeConfig = test.KubeconfigFile(s.T(), kubeconfig)
+		s.InitMcpClient()
+		tools, err := s.ListTools(s.T().Context(), mcp.ListToolsRequest{})
+		s.Run("ListTools returns tools", func() {
+			s.NotNil(tools, "Expected tools from ListTools")
+			s.NoError(err, "Expected no error from ListTools")
+		})
+		s.Run("ListTools returns correct Tool metadata", func() {
+			expectedMetadata := test.ReadFile("testdata", "toolsets-full-tools-multicluster-enum.json")
 			metadata, err := json.MarshalIndent(tools.Tools, "", "  ")
 			s.Require().NoErrorf(err, "failed to marshal tools metadata: %v", err)
 			s.JSONEq(expectedMetadata, string(metadata), "tools metadata does not match expected")

--- a/pkg/mcp/toolsets_test.go
+++ b/pkg/mcp/toolsets_test.go
@@ -143,9 +143,7 @@ func (s *ToolsetsSuite) TestInputSchemaEdgeCases() {
 		}
 		s.Require().NotNil(namespacesList, "Expected namespaces_list from ListTools")
 		s.NotNil(namespacesList.InputSchema.Properties, "Expected namespaces_list.InputSchema.Properties not to be nil")
-		// With multiple clusters available, namespaces_list should have a context parameter
-		_, exists := namespacesList.InputSchema.Properties["context"]
-		s.True(exists, "Expected context property to exist when multiple clusters are available")
+		s.Empty(namespacesList.InputSchema.Properties, "Expected namespaces_list.InputSchema.Properties to be empty")
 	})
 }
 

--- a/pkg/toolsets/config/configuration.go
+++ b/pkg/toolsets/config/configuration.go
@@ -12,43 +12,51 @@ import (
 
 func initConfiguration() []api.ServerTool {
 	tools := []api.ServerTool{
-		{Tool: api.Tool{
-			Name:        "configuration_contexts_list",
-			Description: "List all available context names from the kubeconfig file",
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-			},
-			Annotations: api.ToolAnnotations{
-				Title:           "Configuration: Contexts List",
-				ReadOnlyHint:    ptr.To(true),
-				DestructiveHint: ptr.To(false),
-				IdempotentHint:  ptr.To(true),
-				OpenWorldHint:   ptr.To(false),
-			},
-		}, Handler: contextsList},
-		{Tool: api.Tool{
-			Name:        "configuration_view",
-			Description: "Get the current Kubernetes configuration content as a kubeconfig YAML",
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
-					"minified": {
-						Type: "boolean",
-						Description: "Return a minified version of the configuration. " +
-							"If set to true, keeps only the current-context and the relevant pieces of the configuration for that context. " +
-							"If set to false, all contexts, clusters, auth-infos, and users are returned in the configuration. " +
-							"(Optional, default true)",
-					},
+		{
+			Tool: api.Tool{
+				Name:        "configuration_contexts_list",
+				Description: "List all available context names from the kubeconfig file",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Configuration: Contexts List",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(false),
 				},
 			},
-			Annotations: api.ToolAnnotations{
-				Title:           "Configuration: View",
-				ReadOnlyHint:    ptr.To(true),
-				DestructiveHint: ptr.To(false),
-				IdempotentHint:  ptr.To(false),
-				OpenWorldHint:   ptr.To(true),
+			ClusterAware: ptr.To(false),
+			Handler:      contextsList,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "configuration_view",
+				Description: "Get the current Kubernetes configuration content as a kubeconfig YAML",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"minified": {
+							Type: "boolean",
+							Description: "Return a minified version of the configuration. " +
+								"If set to true, keeps only the current-context and the relevant pieces of the configuration for that context. " +
+								"If set to false, all contexts, clusters, auth-infos, and users are returned in the configuration. " +
+								"(Optional, default true)",
+						},
+					},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Configuration: View",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					IdempotentHint:  ptr.To(false),
+					OpenWorldHint:   ptr.To(true),
+				},
 			},
-		}, Handler: configurationView},
+			ClusterAware: ptr.To(false),
+			Handler:      configurationView,
+		},
 	}
 	return tools
 }

--- a/pkg/toolsets/config/configuration.go
+++ b/pkg/toolsets/config/configuration.go
@@ -62,7 +62,7 @@ func initConfiguration() []api.ServerTool {
 }
 
 func contextsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	contexts, err := params.GetTargets(params.Context)
+	contexts, err := params.ConfigurationContextsList()
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list contexts: %v", err)), nil
 	}
@@ -71,7 +71,10 @@ func contextsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		return api.NewToolCallResult("No contexts found in kubeconfig", nil), nil
 	}
 
-	defaultContext := params.GetDefaultTarget()
+	defaultContext, err := params.ConfigurationContextsDefault()
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get default context: %v", err)), nil
+	}
 
 	result := fmt.Sprintf("Available Kubernetes contexts (%d total, default: %s):\n\n", len(contexts), defaultContext)
 	result += "Format: [*] CONTEXT_NAME\n"
@@ -89,6 +92,7 @@ func contextsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 
 	result += "To use a specific context with any tool, set the 'context' parameter in the tool call arguments"
 
+	// TODO: Review output format, current is not parseable and might not be ideal for LLM consumption
 	return api.NewToolCallResult(result, nil), nil
 }
 

--- a/pkg/toolsets/config/configuration.go
+++ b/pkg/toolsets/config/configuration.go
@@ -27,8 +27,9 @@ func initConfiguration() []api.ServerTool {
 					OpenWorldHint:   ptr.To(false),
 				},
 			},
-			ClusterAware: ptr.To(false),
-			Handler:      contextsList,
+			ClusterAware:       ptr.To(false),
+			TargetListProvider: ptr.To(true),
+			Handler:            contextsList,
 		},
 		{
 			Tool: api.Tool{

--- a/pkg/toolsets/config/configuration.go
+++ b/pkg/toolsets/config/configuration.go
@@ -13,13 +13,13 @@ import (
 func initConfiguration() []api.ServerTool {
 	tools := []api.ServerTool{
 		{Tool: api.Tool{
-			Name:        "contexts_list",
-			Description: "List all available contexts from the kubeconfig file. Shows context names for all available contexts",
+			Name:        "configuration_contexts_list",
+			Description: "List all available context names from the kubeconfig file",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 			},
 			Annotations: api.ToolAnnotations{
-				Title:           "Contexts: List",
+				Title:           "Configuration: Contexts List",
 				ReadOnlyHint:    ptr.To(true),
 				DestructiveHint: ptr.To(false),
 				IdempotentHint:  ptr.To(true),


### PR DESCRIPTION
The original changes look good overall.
The tool mutator is a great way to tackle the multi-cluster problem with minimal impact on the toolsets 🙌 

The Kubernetes module architecture is now quite complex, Provider->Manager->Kubernetes.
We might look into merging Provider and Manager together in the future.

The `InOpenShift` function is making less sense now, especially under the new multi-cluster scenario where some clusters might be openshift while others not.
We should plan for removal. This should also simplify the GetTools-related logic.

In the auth section, I'm not convinced about the changes to `KubernetesApiTokenVerifier`.
However, this will likely be removed. In the token exchange scenario this wasn't relevant any more.

The output for the `configuration_contexts_list` tool should be changed to something LLM friendlier and maybe parseable.

This PRs adds a few changes, but mostly includes tests.
I'll probably add a few more tests once we merge the original PR, since the multi-cluster scenario is not completely tested from the MCP perspective.

The following list contains a detailed outline of the changes this PR includes:
- Renamed `contexts_list` to `configuration_contexts_list`
  - Consistency with rest of tool naming
  - Should allow the LLM _understand_ that the contexts come from a Kubernetes configuration
- Introduced `IsClusterAware` method to avoid using magic strings in ToolMutator
- Introduced `IsTargetListProvider` method to avoid using magic strings in ToolFilter (partially, should be reassessed)
- Removed ManagerProvider from toolsets api
  Ideally, toolset implementation shouldn't need access to lower-level Kubernetes and even less unrestricted access to multiple clusters.
- Reverted edge-case test in toolsets_test, this test is very important and should not be altered.
- Reverted toolset metadata tests
- Added specific multi-cluster toolset metadata tests